### PR TITLE
feat: switch default branch to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,11 @@ name: CI
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
   push:
     branches:
-      - 'master'
-      - 'release'
+      - "main"
+      - "release"
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,11 +4,13 @@ name: "CodeQL"
 # yamllint disable-line rule:truthy
 on:
   push:
-    branches: [master]
+    branches:
+      - main
   pull_request:
-    branches: [master]
+    branches:
+      - main
   schedule:
-    - cron: '31 22 * * 5'
+    - cron: "31 22 * * 5"
 
 jobs:
   analyze:
@@ -22,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['go']
+        language: ["go"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,14 +1,14 @@
 ---
-name: 'lint'
+name: "lint"
 
 # yamllint disable-line rule:truthy
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
   push:
     branches:
-      - 'master'
+      - "main"
 
 jobs:
   hadolint:
@@ -31,8 +31,8 @@ jobs:
         uses: avto-dev/markdown-lint@04d43ee9191307b50935a753da3b775ab695eceb
         # v1.5.0 => 04d43ee9191307b50935a753da3b775ab695eceb
         with:
-          config: '.github/linters/.markdown-lint.yml'
-          args: './README.md'
+          config: ".github/linters/.markdown-lint.yml"
+          args: "./README.md"
 
   shellcheck:
     name: shellcheck
@@ -71,4 +71,4 @@ jobs:
         uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c
         # v3.0.2 => c19bd0523a9011c3a3960fe6640a0882b59af15d
         with:
-          config_file: '.github/linters/.yamllint.yml'
+          config_file: ".github/linters/.yamllint.yml"


### PR DESCRIPTION
Due to local tooling updates, all the other Dokku repositories are converging on 'main' as the default. This makes my local workflows for interacting with this repository annoying as I need to remember if the repo uses main or master. As such, the default branch is moving to main to reduce cognitive overhead while I maintain the repository.