### PR TITLE
feat: add Docker CLI plugin support

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: luizm/action-sh-checker@883217215b11c1fabbf00eb1a9a041f62d74c744
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          SHFMT_OPTS: -l -d -i 2
+          SHFMT_OPTS: -l -d -bn -ci -i 2
         with:
           sh_checker_shellcheck_disable: true
           sh_checker_comment: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN apt-get update \
     && unzip -o /tmp/nomad.zip -d /usr/local/bin/ \
     && chmod +x /usr/local/bin/nomad \
     && rm -f /tmp/nomad.zip \
+    && curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-28.0.4.tgz \
+    && tar --strip-components=1 -xvzf docker-28.0.4.tgz -C /usr/local/bin \
+    && rm docker-28.0.4.tgz \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get update \
     && unzip -o /tmp/nomad.zip -d /usr/local/bin/ \
     && chmod +x /usr/local/bin/nomad \
     && rm -f /tmp/nomad.zip \
-    && curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-28.0.4.tgz \
+    && DOCKER_ARCH=$(uname -m) \
+    && curl -fsSLO "https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-28.0.4.tgz" \
     && tar --strip-components=1 -xvzf docker-28.0.4.tgz -C /usr/local/bin \
     && rm docker-28.0.4.tgz \
     && apt-get clean \

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,16 @@ build: prebuild
 	@$(MAKE) build/deb/$(NAME)_$(VERSION)_amd64.deb
 	@$(MAKE) build/deb/$(NAME)_$(VERSION)_arm64.deb
 
+PLUGIN_NAME = docker-dre
+HOST_OS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
+HOST_ARCH = $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+
+install:
+	@$(MAKE) build/$(HOST_OS)/$(NAME)-$(HOST_ARCH)
+	mkdir -p $(HOME)/.docker/cli-plugins
+	cp build/$(HOST_OS)/$(NAME)-$(HOST_ARCH) $(HOME)/.docker/cli-plugins/$(PLUGIN_NAME)
+	chmod +x $(HOME)/.docker/cli-plugins/$(PLUGIN_NAME)
+
 build-docker-image:
 	docker build --rm -q -f Dockerfile -t $(IMAGE_NAME):build .
 
@@ -122,6 +132,7 @@ build/deb/$(NAME)_$(VERSION)_amd64.deb: build/linux/$(NAME)-amd64
 		--version $(VERSION) \
 		--verbose \
 		build/linux/$(NAME)-amd64=/usr/bin/$(NAME) \
+		build/linux/$(NAME)-amd64=/usr/libexec/docker/cli-plugins/$(PLUGIN_NAME) \
 		LICENSE=/usr/share/doc/$(NAME)/copyright
 
 build/deb/$(NAME)_$(VERSION)_arm64.deb: build/linux/$(NAME)-arm64
@@ -142,6 +153,7 @@ build/deb/$(NAME)_$(VERSION)_arm64.deb: build/linux/$(NAME)-arm64
 		--version $(VERSION) \
 		--verbose \
 		build/linux/$(NAME)-arm64=/usr/bin/$(NAME) \
+		build/linux/$(NAME)-arm64=/usr/libexec/docker/cli-plugins/$(PLUGIN_NAME) \
 		LICENSE=/usr/share/doc/$(NAME)/copyright
 
 clean:
@@ -173,6 +185,7 @@ release: build bin/gh-release bin/gh-release-body
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_arm64.tgz -C build/darwin $(NAME)-arm64
 	cp build/deb/$(NAME)_$(VERSION)_amd64.deb release/$(NAME)_$(VERSION)_amd64.deb
 	cp build/deb/$(NAME)_$(VERSION)_arm64.deb release/$(NAME)_$(VERSION)_arm64.deb
+	cp install.sh release/install.sh
 	bin/gh-release create $(MAINTAINER)/$(REPOSITORY) $(VERSION) $(shell git rev-parse --abbrev-ref HEAD)
 	bin/gh-release-body $(MAINTAINER)/$(REPOSITORY) v$(VERSION)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,37 @@ go build
 - nomad-json `job.json`: [Docs](/docs/nomad.md)
 - kubernetes `deployment.yml`: Use [kompose](https://kompose.io/)
 
+## Docker CLI plugin
+
+`docker-run-export` can be invoked as a [Docker CLI plugin](https://github.com/docker/cli/issues/1534), exposing every subcommand under `docker dre`:
+
+```shell
+docker dre run --dre-format compose alpine:latest
+# equivalent to
+docker-run-export run --dre-format compose alpine:latest
+```
+
+The plugin binary is named `docker-dre` (Docker CLI plugin names must be lowercase alphanumeric, no hyphens). It is registered as a plugin by placing (or symlinking) it into one of Docker's plugin lookup directories:
+
+- Per-user: `~/.docker/cli-plugins/docker-dre`
+- System-wide (Linux): `/usr/libexec/docker/cli-plugins/docker-dre` or `/usr/local/lib/docker/cli-plugins/docker-dre`
+- System-wide (Homebrew): `$(brew --prefix)/lib/docker/cli-plugins/docker-dre`
+
+The supported distribution channels wire this up automatically:
+
+- **Debian/Ubuntu:** the `.deb` package installs both `/usr/bin/docker-run-export` (for direct invocation) and `/usr/libexec/docker/cli-plugins/docker-dre` (for Docker CLI plugin lookup).
+- **Homebrew:** `brew install docker-run-export` places the binary under `bin/` and symlinks it into Homebrew's `lib/docker/cli-plugins/`.
+- **Release tarball / install script:** run
+
+  ```shell
+  curl -fsSL https://raw.githubusercontent.com/dokku/docker-run-export/main/install.sh | sh
+  ```
+
+  to download the appropriate release tarball for your OS/arch and install the binary at `~/.docker/cli-plugins/docker-dre`.
+- **From source:** `make install` builds for your current OS/arch and drops the binary into `~/.docker/cli-plugins/`.
+
+Once installed, `docker --help` will list `dre*` under the "Plugin commands" section, and `docker dre <subcommand>` works identically to the bare binary.
+
 ## Usage
 
 > Warning: not all formats will support all flags. Warnings will be emitted on stderr. Some flags may be validated if they contain units or formatting of some sort, which may result in errors being output as well.

--- a/commands/docker_cli_plugin_metadata.go
+++ b/commands/docker_cli_plugin_metadata.go
@@ -1,0 +1,100 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/posener/complete"
+	flag "github.com/spf13/pflag"
+)
+
+// DockerCliPluginMetadataCommand is the command for the plugin metadata
+type DockerCliPluginMetadataCommand struct {
+	command.Meta
+	// Version is the version of the plugin
+	Version string
+}
+
+// PluginMetadata is the metadata for the plugin
+type PluginMetadata struct {
+	// SchemaVersion is the schema version of the plugin
+	SchemaVersion string `json:"SchemaVersion"`
+	// Vendor is the vendor of the plugin
+	Vendor string `json:"Vendor"`
+	// Version is the version of the plugin
+	Version string `json:"Version"`
+	// ShortDescription is the short description of the plugin
+	ShortDescription string `json:"ShortDescription"`
+}
+
+func (c *DockerCliPluginMetadataCommand) Name() string {
+	return "docker-cli-plugin-metadata"
+}
+
+func (c *DockerCliPluginMetadataCommand) Synopsis() string {
+	return "Prints the metadata for the Docker CLI plugin"
+}
+
+func (c *DockerCliPluginMetadataCommand) Help() string {
+	return command.CommandHelp(c)
+}
+
+func (c *DockerCliPluginMetadataCommand) Examples() map[string]string {
+	appName := os.Getenv("CLI_APP_NAME")
+	return map[string]string{
+		"Prints the metadata for the Docker CLI plugin": fmt.Sprintf("%s %s", appName, c.Name()),
+	}
+}
+
+func (c *DockerCliPluginMetadataCommand) Arguments() []command.Argument {
+	return []command.Argument{}
+}
+
+func (c *DockerCliPluginMetadataCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *DockerCliPluginMetadataCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {
+	return command.ParseArguments(args, c.Arguments())
+}
+
+func (c *DockerCliPluginMetadataCommand) FlagSet() *flag.FlagSet {
+	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	return f
+}
+
+func (c *DockerCliPluginMetadataCommand) AutocompleteFlags() complete.Flags {
+	return command.MergeAutocompleteFlags(
+		c.Meta.AutocompleteFlags(command.FlagSetClient),
+		complete.Flags{},
+	)
+}
+
+func (c *DockerCliPluginMetadataCommand) Run(args []string) int {
+	flags := c.FlagSet()
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	metadata := PluginMetadata{
+		SchemaVersion:    "0.1.0",
+		Vendor:           "Jose Diaz-Gonzalez",
+		Version:          c.Version,
+		ShortDescription: "Exports the flags passed to a docker run call to a variety of formats",
+	}
+
+	jsonData, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling metadata: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(jsonData))
+
+	return 0
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+# Install docker-run-export as a Docker CLI plugin in the
+# current user's ~/.docker/cli-plugins/ directory.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/dokku/docker-run-export/main/install.sh | sh
+#   VERSION=v0.2.0 curl -fsSL https://raw.githubusercontent.com/dokku/docker-run-export/main/install.sh | sh
+#
+# Environment variables:
+#   VERSION    Release tag to install (defaults to the latest release).
+#   PLUGIN_DIR Override destination directory (defaults to $HOME/.docker/cli-plugins).
+
+set -eu
+
+NAME="docker-run-export"
+PLUGIN_NAME="docker-dre"
+REPO="dokku/docker-run-export"
+PLUGIN_DIR="${PLUGIN_DIR:-${HOME}/.docker/cli-plugins}"
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$os" in
+  linux | darwin) ;;
+  *)
+    echo "error: unsupported OS: $os" >&2
+    exit 1
+    ;;
+esac
+
+arch="$(uname -m)"
+case "$arch" in
+  x86_64 | amd64) arch="amd64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *)
+    echo "error: unsupported architecture: $arch" >&2
+    exit 1
+    ;;
+esac
+
+if [ -z "${VERSION:-}" ]; then
+  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | sed -n 's/.*"tag_name": "\(.*\)".*/\1/p' | head -n1)"
+fi
+
+if [ -z "$VERSION" ]; then
+  echo "error: could not determine latest version; set VERSION explicitly" >&2
+  exit 1
+fi
+
+# Release assets are tarballs named like docker-run-export_<VER>_<os>_<arch>.tgz
+# containing a single binary docker-run-export-<arch>.
+asset="${NAME}_${VERSION#v}_${os}_${arch}.tgz"
+url="https://github.com/${REPO}/releases/download/${VERSION}/${asset}"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+echo "downloading ${url}"
+curl -fsSL "$url" -o "${tmpdir}/${asset}"
+tar -xzf "${tmpdir}/${asset}" -C "$tmpdir"
+
+mkdir -p "$PLUGIN_DIR"
+install -m 0755 "${tmpdir}/${NAME}-${arch}" "${PLUGIN_DIR}/${PLUGIN_NAME}"
+
+echo "installed ${NAME} ${VERSION} to ${PLUGIN_DIR}/${PLUGIN_NAME}"
+echo "try: docker dre version"

--- a/main.go
+++ b/main.go
@@ -25,9 +25,21 @@ func main() {
 func Run(args []string) int {
 	ctx := context.Background()
 	commandMeta := command.SetupRun(ctx, AppName, Version, args)
+
+	cliArgs := os.Args[1:]
+	// When invoked by `docker <plugin-name> ...`, Docker CLI prepends the
+	// plugin name as argv[1] and sets DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND.
+	// Strip the prepended name only in that case so direct invocations keep
+	// their args intact.
+	if os.Getenv("DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND") != "" &&
+		len(os.Args) > 1 && os.Args[1] == "dre" {
+		cliArgs = os.Args[2:]
+	}
+
 	c := cli.NewCLI(AppName, Version)
-	c.Args = os.Args[1:]
+	c.Args = cliArgs
 	c.Commands = command.Commands(ctx, commandMeta, Commands)
+	c.HiddenCommands = []string{"docker-cli-plugin-metadata"}
 	exitCode, err := c.Run()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error executing CLI: %s\n", err.Error())
@@ -40,6 +52,9 @@ func Run(args []string) int {
 // Returns a list of implemented commands
 func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFactory {
 	return map[string]cli.CommandFactory{
+		"docker-cli-plugin-metadata": func() (cli.Command, error) {
+			return &commands.DockerCliPluginMetadataCommand{Meta: meta, Version: Version}, nil
+		},
 		"run": func() (cli.Command, error) {
 			return &commands.ExportCommand{Meta: meta}, nil
 		},

--- a/test.bats
+++ b/test.bats
@@ -1,10 +1,12 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 export SYSTEM_NAME="$(uname -s | tr '[:upper:]' '[:lower:]')"
 case "$(uname -m)" in
-x86_64 | amd64) export SYSTEM_ARCH="amd64" ;;
-aarch64 | arm64) export SYSTEM_ARCH="arm64" ;;
-*) export SYSTEM_ARCH="amd64" ;;
+  x86_64 | amd64) export SYSTEM_ARCH="amd64" ;;
+  aarch64 | arm64) export SYSTEM_ARCH="arm64" ;;
+  *) export SYSTEM_ARCH="amd64" ;;
 esac
 export DOCKER_RUN_EXPORT_BIN="build/$SYSTEM_NAME/docker-run-export-$SYSTEM_ARCH"
 
@@ -13,7 +15,13 @@ setup_file() {
 }
 
 teardown_file() {
+  rm -f "$HOME/.docker/cli-plugins/docker-dre"
   make clean
+}
+
+setup() {
+  mkdir -p "$HOME/.docker/cli-plugins"
+  cp "$DOCKER_RUN_EXPORT_BIN" "$HOME/.docker/cli-plugins/docker-dre"
 }
 
 # Helper: query the YAML portion of the output with yq
@@ -2125,4 +2133,82 @@ nomad_validate_json() {
     alpine:latest
   [[ "$status" -eq 0 ]]
   nomad_validate_hcl
+}
+
+@test "[plugin] docker-cli-plugin-metadata returns valid JSON" {
+  run "$DOCKER_RUN_EXPORT_BIN" docker-cli-plugin-metadata
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "'$DOCKER_RUN_EXPORT_BIN' docker-cli-plugin-metadata | jq -r .SchemaVersion"
+  assert_success
+  assert_output "0.1.0"
+
+  run /bin/bash -c "'$DOCKER_RUN_EXPORT_BIN' docker-cli-plugin-metadata | jq -e '.Vendor != \"\"'"
+  assert_success
+
+  run /bin/bash -c "'$DOCKER_RUN_EXPORT_BIN' docker-cli-plugin-metadata | jq -e '.ShortDescription != \"\"'"
+  assert_success
+}
+
+@test "[plugin] docker-cli-plugin-metadata is hidden from --help" {
+  run /bin/bash -c "'$DOCKER_RUN_EXPORT_BIN' --help 2>&1"
+  echo "output: $output"
+  echo "status: $status"
+  [[ "$output" != *"docker-cli-plugin-metadata"* ]] || flunk "expected --help not to list docker-cli-plugin-metadata"
+}
+
+@test "[plugin] docker dre version" {
+  run docker dre version
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  [[ -n "$output" ]] || flunk "expected non-empty version output"
+}
+
+@test "[plugin] docker dre run" {
+  run docker dre run --dre-format compose --dre-project testapp alpine:latest echo hello
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "services:"
+}
+
+@test "[plugin] direct invocation without prefix still works" {
+  run "$DOCKER_RUN_EXPORT_BIN" version
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
+flunk() {
+  {
+    if [[ "$#" -eq 0 ]]; then
+      cat -
+    else
+      echo "$@"
+    fi
+  } >&2
+  return 1
+}
+
+assert_success() {
+  if [[ "$status" -ne 0 ]]; then
+    flunk "command failed with exit status $status"
+  fi
+}
+
+assert_output() {
+  local expected="$1"
+  if [[ "$output" != "$expected" ]]; then
+    flunk "expected output: $expected\nactual output: $output"
+  fi
+}
+
+assert_output_contains() {
+  local expected="$1"
+  if [[ "$output" != *"$expected"* ]]; then
+    flunk "expected output to contain: $expected\nactual output: $output"
+  fi
 }


### PR DESCRIPTION
## Summary

- Registers the binary as a Docker CLI plugin, invokable as `docker dre [subcommand]` in addition to the existing `docker-run-export` direct invocation.
- Plugin binary is named `docker-dre` since Docker CLI plugin names must match `^[a-z][a-z0-9]*$` (no hyphens).
- Adds a hidden `docker-cli-plugin-metadata` subcommand emitting the JSON metadata Docker expects.
- Arg-strip is gated on `DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND` env var so direct invocations are unaffected.
- Deb packages now also install to `/usr/libexec/docker/cli-plugins/docker-dre`.
- Adds `make install` target and `install.sh` for curl-pipe installation.

Paired with dokku/homebrew-repo#118 for the Homebrew formula symlink.