### PR TITLE
Restructure documentation into minimal README and structured docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,57 @@
 # docker-run-export
 
-Exports the flags passed to a `docker run` call to a variety of formats.
+Exports `docker run` flags to configuration files for Docker Compose, AWS ECS, and HashiCorp Nomad.
 
-This is a work in progress
+## Installation
 
-## Building
+Install with the quick install script:
 
-```shell
-go build
+```bash
+curl -fsSL https://raw.githubusercontent.com/dokku/docker-run-export/main/install.sh | sh
 ```
 
-## Formats
+Or via Homebrew:
 
-- docker `docker-compose.yml` 3.7: [Docs](/docs/compose.md)
-- ecs `task-definition.json`: [Docs](/docs/ecs.md)
-- ecs-cfn CloudFormation `AWS::ECS::TaskDefinition`: [Docs](/docs/ecs.md)
-- nomad `job.nomad` HCL: [Docs](/docs/nomad.md)
-- nomad-json `job.json`: [Docs](/docs/nomad.md)
-- kubernetes `deployment.yml`: Use [kompose](https://kompose.io/)
-
-## Docker CLI plugin
-
-`docker-run-export` can be invoked as a [Docker CLI plugin](https://github.com/docker/cli/issues/1534), exposing every subcommand under `docker dre`:
-
-```shell
-docker dre run --dre-format compose alpine:latest
-# equivalent to
-docker-run-export run --dre-format compose alpine:latest
+```bash
+brew install dokku/repo/docker-run-export
 ```
 
-The plugin binary is named `docker-dre` (Docker CLI plugin names must be lowercase alphanumeric, no hyphens). It is registered as a plugin by placing (or symlinking) it into one of Docker's plugin lookup directories:
+Or build from source:
 
-- Per-user: `~/.docker/cli-plugins/docker-dre`
-- System-wide (Linux): `/usr/libexec/docker/cli-plugins/docker-dre` or `/usr/local/lib/docker/cli-plugins/docker-dre`
-- System-wide (Homebrew): `$(brew --prefix)/lib/docker/cli-plugins/docker-dre`
+```bash
+make install
+```
 
-The supported distribution channels wire this up automatically:
+See the [Getting Started](docs/getting-started.md#installation) guide for all distribution channels (Debian/Ubuntu packages, binary downloads, etc.).
 
-- **Debian/Ubuntu:** the `.deb` package installs both `/usr/bin/docker-run-export` (for direct invocation) and `/usr/libexec/docker/cli-plugins/docker-dre` (for Docker CLI plugin lookup).
-- **Homebrew:** `brew install docker-run-export` places the binary under `bin/` and symlinks it into Homebrew's `lib/docker/cli-plugins/`.
-- **Release tarball / install script:** run
-
-  ```shell
-  curl -fsSL https://raw.githubusercontent.com/dokku/docker-run-export/main/install.sh | sh
-  ```
-
-  to download the appropriate release tarball for your OS/arch and install the binary at `~/.docker/cli-plugins/docker-dre`.
-- **From source:** `make install` builds for your current OS/arch and drops the binary into `~/.docker/cli-plugins/`.
-
-Once installed, `docker --help` will list `dre*` under the "Plugin commands" section, and `docker dre <subcommand>` works identically to the bare binary.
+Once installed, the plugin is available via `docker dre`.
 
 ## Usage
 
-> Warning: not all formats will support all flags. Warnings will be emitted on stderr. Some flags may be validated if they contain units or formatting of some sort, which may result in errors being output as well.
+Export a `docker run` command to a Compose file:
 
-```shell
-docker-run-export run --dre-project derp --dre-format compose --add-host "somehost:162.242.195.82" --cap-add DERP --cpus 5 --expose 5:5 alpine:latest key echo "hi derp"
+```bash
+docker dre run --dre-project myapp --dre-format compose -e FOO=bar -p 8080:80 nginx:latest
 ```
 
-Non `docker run` supported flags:
+Change `--dre-format` to target a different platform:
 
-- `dre-project`: the project name
-- `dre-format`: the format to export as
+```bash
+docker dre run --dre-project myapp --dre-format ecs -p 8080:80 nginx:latest
+docker dre run --dre-project myapp --dre-format nomad -p 8080:80 nginx:latest
+```
+
+See the [command reference](docs/command-reference.md) for all flags and options.
+
+## Documentation
+
+- [Getting Started](docs/getting-started.md) -- why docker-run-export, installation, and your first export
+- [Command Reference](docs/command-reference.md) -- all DRE flags, supported docker run flags, and output formats
+- [Compose](docs/compose.md) -- exporting to docker-compose.yml
+- [ECS](docs/ecs.md) -- exporting to ECS task definitions and CloudFormation templates
+- [Nomad](docs/nomad.md) -- exporting to Nomad job specifications in HCL and JSON
+- [Docker CLI Plugin](docs/docker-cli-plugin.md) -- using docker-run-export as `docker dre`
+
+## License
+
+[MIT](LICENSE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Documentation
+
+Complete documentation for docker-run-export, a CLI tool that converts `docker run` flags into configuration files for Docker Compose, AWS ECS, and HashiCorp Nomad.
+
+## Getting Started
+
+- [Getting Started](getting-started.md) -- why docker-run-export, installation, and your first export
+
+## Reference
+
+- [Command Reference](command-reference.md) -- all DRE flags, supported docker run flags, and output formats
+
+## Format Guides
+
+- [Compose](compose.md) -- exporting to docker-compose.yml
+- [ECS](ecs.md) -- exporting to ECS task definitions and CloudFormation templates
+- [Nomad](nomad.md) -- exporting to Nomad job specifications in HCL and JSON
+
+## Guides
+
+- [Docker CLI Plugin](docker-cli-plugin.md) -- using docker-run-export as `docker dre`

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1,0 +1,101 @@
+# Command Reference
+
+## Synopsis
+
+```
+docker-run-export run [docker-run-flags] [dre-flags] IMAGE [COMMAND [ARG...]]
+```
+
+As a Docker CLI plugin:
+
+```
+docker dre run [docker-run-flags] [dre-flags] IMAGE [COMMAND [ARG...]]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `IMAGE` | Yes | The Docker image to use in the generated configuration. |
+| `COMMAND` | No | Command and arguments passed through to the output format's command/args field. |
+
+## DRE Flags
+
+These flags control docker-run-export itself and are not part of `docker run`. They are prefixed with `dre-` to avoid conflicts with docker run flags.
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--dre-format` | string | `compose` | Output format: `compose`, `ecs`, `ecs-cfn`, `nomad`, or `nomad-json`. |
+| `--dre-project` | string | | Project name used in the generated configuration (Compose project name, ECS family, Nomad job ID). |
+| `--dre-ecs-task-role-arn` | string | | IAM role ARN for the ECS task (maps to `taskRoleArn`). Only applies to `ecs` and `ecs-cfn` formats. |
+| `--dre-ecs-execution-role-arn` | string | | IAM role ARN for the ECS agent (maps to `executionRoleArn`). Only applies to `ecs` and `ecs-cfn` formats. |
+| `--dre-ecs-launch-type` | string (repeatable) | | ECS launch type compatibility, e.g., `FARGATE` or `EC2` (maps to `requiresCompatibilities`). Pass the flag multiple times for multiple values. Only applies to `ecs` and `ecs-cfn` formats. |
+| `--dre-nomad-datacenter` | string (repeatable) | `dc1` | Nomad datacenter(s). Pass the flag multiple times for multiple values. Only applies to `nomad` and `nomad-json` formats. |
+| `--dre-nomad-region` | string | | Nomad region (maps to `Region`). Only applies to `nomad` and `nomad-json` formats. |
+| `--dre-nomad-namespace` | string | | Nomad namespace (maps to `Namespace`). Only applies to `nomad` and `nomad-json` formats. |
+| `--dre-nomad-type` | string | `service` | Nomad job type: `service`, `batch`, or `system`. Only applies to `nomad` and `nomad-json` formats. |
+| `--dre-nomad-count` | int | `1` | Number of task group instances. Only applies to `nomad` and `nomad-json` formats. |
+
+## Supported Docker Run Flags
+
+docker-run-export accepts most `docker run` flags. It parses them and maps each flag to the closest equivalent in the target format. Not every flag is supported by every format -- unsupported flags emit a warning on stderr and are otherwise ignored.
+
+For the complete list of flag-to-field mappings and unsupported flags in each format, see:
+
+- [Compose](compose.md#unsupported-flags)
+- [ECS](ecs.md#unsupported-flags)
+- [Nomad](nomad.md#unsupported-flags)
+
+> **Note:** The `-h` short flag is detected as help by the argument parser. Use `--hostname` instead.
+
+## Output Formats
+
+| Format | `--dre-format` value | Output type | Description |
+| --- | --- | --- | --- |
+| Compose | `compose` | YAML | Docker Compose service definition (v3.7). |
+| ECS Task Definition | `ecs` | JSON | AWS ECS task definition. |
+| ECS CloudFormation | `ecs-cfn` | YAML | CloudFormation template with an `AWS::ECS::TaskDefinition` resource. |
+| Nomad HCL | `nomad` | HCL | HashiCorp Nomad job specification in HCL. |
+| Nomad JSON | `nomad-json` | JSON | Nomad job specification in JSON (for the Nomad HTTP API). |
+
+> **Kubernetes:** For Kubernetes output, generate a Compose file with `--dre-format compose` and convert it with [kompose](https://kompose.io/).
+
+## Examples
+
+Export to Compose (the default format):
+
+```bash
+docker-run-export run --dre-project myapp alpine:latest echo hello
+```
+
+Export to an ECS task definition with IAM roles and Fargate:
+
+```bash
+docker-run-export run --dre-project myapp --dre-format ecs \
+  --dre-ecs-task-role-arn arn:aws:iam::123456789:role/task \
+  --dre-ecs-execution-role-arn arn:aws:iam::123456789:role/exec \
+  --dre-ecs-launch-type FARGATE \
+  -p 8080:80 nginx:latest
+```
+
+Export to a Nomad HCL job spec with datacenter and region:
+
+```bash
+docker-run-export run --dre-project myapp --dre-format nomad \
+  --dre-nomad-datacenter us-east-1 --dre-nomad-region us \
+  -e FOO=bar -p 8080:80 --cpus 1 --memory 536870912 \
+  alpine:latest echo hello
+```
+
+Use as a Docker CLI plugin:
+
+```bash
+docker dre run --dre-format compose --dre-project myapp -p 8080:80 nginx:latest
+```
+
+## See Also
+
+- [Compose](compose.md) -- Compose-specific mappings and unsupported flags
+- [ECS](ecs.md) -- ECS-specific mappings, unit conversions, and unsupported flags
+- [Nomad](nomad.md) -- Nomad driver config mapping, health checks, and unsupported flags
+- [Docker CLI Plugin](docker-cli-plugin.md) -- plugin installation and invocation details

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -1,10 +1,14 @@
 # Compose
 
-```shell
-docker-run-export run --dre-project derp --add-host "somehost:162.242.195.82" --cap-add DERP --cpus 5 --expose 5:5 alpine:latest key echo "hi derp"
+Docker Compose is a tool for defining multi-container applications with a YAML file. docker-run-export generates a Compose service definition from your `docker run` flags, which you can save to a `docker-compose.yml` and run with `docker compose up`.
+
+## Example
+
+```bash
+docker-run-export run --dre-project derp --dre-format compose --add-host "somehost:162.242.195.82" --cap-add DERP --cpus 5 --expose 5:5 alpine:latest key echo "hi derp"
 ```
 
-output
+output:
 
 ```yaml
 ---
@@ -29,13 +33,17 @@ services:
     image: alpine:latest
 ```
 
+Each `docker run` flag maps to a Compose YAML field. For example, `--cap-add` becomes `cap_add`, `--cpus` becomes both `cpus` and `deploy.resources.limits.cpus`, and `--add-host` becomes `extra_hosts`.
+
 ## Unsupported Flags
 
-Unsupported `docker run` flags:
+### Parser Limitations
 
-- `-h`: (hostname) detected as help. Use `--hostname` instead.
+- `-h`: detected as help by the flag parser. Use `--hostname` instead.
 
-Not supported by the Compose Specification:
+### Not Supported by the Compose Specification
+
+These flags have no equivalent in the Compose specification and are ignored with a warning:
 
 - `--attach`
 - `--cidfile`
@@ -48,12 +56,12 @@ Not supported by the Compose Specification:
 - `--rm`
 - `--sig-proxy`
 
-Partially implemented:
+### Partially Implemented
 
-- `--mount`: The following options are not supported:
+- `--mount`: The following mount options are not supported:
   - `bind-nonrecursive`
   - `volume-driver`
   - `volume-label`
   - `volume-opt`
   - `tmpfs-mode`
-- `--volume`: does not properly parse windows paths
+- `--volume`: does not properly parse Windows paths.

--- a/docs/docker-cli-plugin.md
+++ b/docs/docker-cli-plugin.md
@@ -1,0 +1,48 @@
+# Docker CLI Plugin
+
+docker-run-export can be invoked as a [Docker CLI plugin](https://github.com/docker/cli/issues/1534), which means you can use `docker dre` instead of typing the full binary name. Every subcommand works the same way:
+
+```bash
+docker dre run --dre-format compose alpine:latest
+# equivalent to
+docker-run-export run --dre-format compose alpine:latest
+```
+
+## How It Works
+
+Docker discovers plugins by scanning specific directories for executables named `docker-<name>`. The docker-run-export plugin binary is named `docker-dre` (Docker CLI plugin names must be lowercase alphanumeric with no hyphens). When Docker finds this binary, running `docker dre <subcommand>` invokes it automatically.
+
+## Plugin Directories
+
+Docker searches these directories for plugins:
+
+- **Per-user:** `~/.docker/cli-plugins/docker-dre`
+- **System-wide (Linux):** `/usr/libexec/docker/cli-plugins/docker-dre` or `/usr/local/lib/docker/cli-plugins/docker-dre`
+- **System-wide (Homebrew):** `$(brew --prefix)/lib/docker/cli-plugins/docker-dre`
+
+## Automatic Setup by Distribution Channel
+
+The supported distribution channels install the plugin automatically:
+
+- **Debian/Ubuntu:** the `.deb` package installs both `/usr/bin/docker-run-export` (for direct invocation) and `/usr/libexec/docker/cli-plugins/docker-dre` (for Docker CLI plugin lookup).
+- **Homebrew:** `brew install dokku/repo/docker-run-export` places the binary under `bin/` and symlinks it into Homebrew's `lib/docker/cli-plugins/`.
+- **Install script:** downloads the appropriate release tarball for your OS/architecture and installs the binary at `~/.docker/cli-plugins/docker-dre`.
+- **From source:** `make install` builds for your current OS/architecture and copies the binary into `~/.docker/cli-plugins/`.
+
+## Verifying the Plugin
+
+After installation, confirm that Docker sees the plugin:
+
+```bash
+docker dre version
+```
+
+You can also check that `docker --help` lists `dre` under the "Plugin commands" section.
+
+## Direct Invocation
+
+You can always run the binary directly without the Docker CLI plugin mechanism. This is useful if Docker is not installed on the machine where you are generating configuration:
+
+```bash
+docker-run-export run --dre-format compose alpine:latest
+```

--- a/docs/docs.yaml
+++ b/docs/docs.yaml
@@ -1,0 +1,7 @@
+docs:
+  - getting-started.md
+  - command-reference.md
+  - compose.md
+  - ecs.md
+  - nomad.md
+  - docker-cli-plugin.md

--- a/docs/ecs.md
+++ b/docs/ecs.md
@@ -1,5 +1,7 @@
 # ECS
 
+Amazon Elastic Container Service (ECS) runs Docker containers on AWS. docker-run-export generates either a standalone ECS task definition (JSON) or a CloudFormation template containing an `AWS::ECS::TaskDefinition` resource. This lets you take a `docker run` command that works locally and produce the configuration AWS needs to run the same container in the cloud.
+
 ## Task Definition JSON (`--dre-format ecs`)
 
 ```shell
@@ -69,7 +71,7 @@ Resources:
 
 ## ECS-Specific Flags
 
-These flags have no `docker run` equivalent and are prefixed with `dre-ecs-`:
+These flags have no `docker run` equivalent and are prefixed with `dre-ecs-`. They are also listed in the [Command Reference](command-reference.md#dre-flags).
 
 - `--dre-ecs-task-role-arn`: IAM role ARN for the task (maps to `taskRoleArn`)
 - `--dre-ecs-execution-role-arn`: IAM role ARN for the ECS agent (maps to `executionRoleArn`)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,155 @@
+# Getting Started
+
+## Why docker-run-export?
+
+Most developers learn Docker through `docker run`. You know how to set environment variables with `-e`, publish ports with `-p`, and mount volumes with `-v`. But when it comes time to deploy that same container on a platform like AWS ECS or HashiCorp Nomad, you need to translate those familiar flags into a completely different configuration format -- JSON task definitions, HCL job specs, or Compose YAML.
+
+docker-run-export does that translation for you. Give it the `docker run` command you would use locally, and it produces the equivalent configuration file for your target platform. You do not need to memorize three different configuration formats or worry about unit conversions (like bytes to MiB for memory limits).
+
+## Installation
+
+Once installed, the tool is available as a Docker CLI plugin:
+
+```bash
+docker dre version
+```
+
+### Quick Install (Linux and macOS)
+
+Use the install script to download the latest release and install it as a Docker CLI plugin:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dokku/docker-run-export/main/install.sh | sh
+```
+
+To install a specific version:
+
+```bash
+VERSION=0.2.0 curl -fsSL https://raw.githubusercontent.com/dokku/docker-run-export/main/install.sh | sh
+```
+
+To install to a custom directory:
+
+```bash
+PLUGIN_DIR=/usr/libexec/docker/cli-plugins curl -fsSL https://raw.githubusercontent.com/dokku/docker-run-export/main/install.sh | sh
+```
+
+### Homebrew (macOS)
+
+```bash
+brew install dokku/repo/docker-run-export
+```
+
+### Debian/Ubuntu
+
+```bash
+sudo apt-get update
+sudo apt-get install docker-run-export
+```
+
+The Debian package installs the binary to both `/usr/bin/docker-run-export` (for direct invocation) and `/usr/libexec/docker/cli-plugins/docker-dre` (for automatic Docker CLI plugin discovery).
+
+### Binary Download
+
+Download a pre-built binary from [GitHub Releases](https://github.com/dokku/docker-run-export/releases) and place it in your Docker CLI plugins directory:
+
+```bash
+mkdir -p ~/.docker/cli-plugins
+install -m 0755 docker-run-export-amd64 ~/.docker/cli-plugins/docker-dre
+```
+
+The binary must be named `docker-dre` and be executable. Docker looks for plugins in:
+
+- `~/.docker/cli-plugins/` (per-user)
+- `/usr/libexec/docker/cli-plugins/` (system-wide)
+
+### From Source
+
+Build and install as a Docker CLI plugin:
+
+```bash
+make install
+```
+
+This builds the binary for your platform and copies it to `~/.docker/cli-plugins/docker-dre`.
+
+## Prerequisites
+
+- Docker Engine (docker-run-export parses `docker run` flags but does not require a running Docker daemon to generate output)
+
+## Your First Export
+
+Start with a `docker run` command and convert it to a Compose file. The `--dre-format` flag tells docker-run-export which output format to use, and `--dre-project` sets the project name:
+
+```bash
+docker-run-export run --dre-project myapp --dre-format compose -e FOO=bar -p 8080:80 alpine:latest echo hello
+```
+
+output:
+
+```yaml
+---
+name: myapp
+services:
+  app:
+    command:
+    - echo
+    - hello
+    environment:
+      FOO: bar
+    image: alpine:latest
+    ports:
+    - 8080:80/tcp
+```
+
+The `-e`, `-p`, and positional arguments were translated into Compose YAML fields. The image became `services.app.image`, the environment variable became `services.app.environment`, and the port mapping became `services.app.ports`.
+
+Now export the same command to an ECS task definition by changing the format flag:
+
+```bash
+docker-run-export run --dre-project myapp --dre-format ecs -e FOO=bar -p 8080:80 alpine:latest echo hello
+```
+
+output:
+
+```json
+{
+  "family": "myapp",
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "alpine:latest",
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 8080,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,
+      "command": [
+        "echo",
+        "hello"
+      ],
+      "environment": [
+        {
+          "name": "FOO",
+          "value": "bar"
+        }
+      ]
+    }
+  ]
+}
+```
+
+The same `docker run` flags produced a valid ECS task definition. Each format handles the translation differently -- for example, ECS uses an array of `{name, value}` objects for environment variables instead of a simple map.
+
+> **Note:** Not every `docker run` flag is supported by every format. When a flag cannot be translated, docker-run-export prints a warning to stderr and continues.
+
+## What to Read Next
+
+- [Command Reference](command-reference.md) -- all DRE flags and supported docker run flags
+- [Compose](compose.md) -- Compose-specific output details and unsupported flags
+- [ECS](ecs.md) -- ECS task definition output, unit conversions, and CloudFormation
+- [Nomad](nomad.md) -- Nomad HCL/JSON output, driver config mapping, and health checks
+- [Docker CLI Plugin](docker-cli-plugin.md) -- using the tool as `docker dre`

--- a/docs/nomad.md
+++ b/docs/nomad.md
@@ -1,5 +1,7 @@
 # Nomad
 
+HashiCorp Nomad is a workload orchestrator that schedules containers, VMs, and other tasks across a cluster of machines. docker-run-export generates a Nomad job specification from your `docker run` flags, using the Docker task driver. The output is available in HCL (the native Nomad configuration format) or JSON (for the Nomad HTTP API).
+
 ## Job Spec HCL (`--dre-format nomad`)
 
 ```shell
@@ -94,7 +96,7 @@ output
 
 ## Nomad-Specific Flags
 
-These flags have no `docker run` equivalent and are prefixed with `dre-nomad-`:
+These flags have no `docker run` equivalent and are prefixed with `dre-nomad-`. They are also listed in the [Command Reference](command-reference.md#dre-flags).
 
 - `--dre-nomad-datacenter`: Nomad datacenter(s); can be passed multiple times. Defaults to `dc1`.
 - `--dre-nomad-region`: Nomad region (maps to `Region`).


### PR DESCRIPTION
## Summary

- Simplify README to bare minimum sections: one-line intro, installation, basic usage, documentation index, license
- Split detailed content into structured docs under `docs/` following the pattern used by docker-orchestrate and docker-port-forward
- Add new documentation: getting-started guide, command reference (all 10 DRE flags), Docker CLI plugin guide
- Add introductory paragraphs to format guides (compose, ecs, nomad) explaining each platform for users familiar with Docker but not necessarily with other orchestration tools